### PR TITLE
Fix stream subscription leaks in MapProvider

### DIFF
--- a/lib/providers/map_provider.dart
+++ b/lib/providers/map_provider.dart
@@ -12,10 +12,20 @@ import '../services/sensor_service.dart';
 import '../services/notification_service.dart';
 
 class MapProvider with ChangeNotifier {
-  final EstacionamientoService _estacionamientoService = EstacionamientoService();
-  final LocationService _locationService = LocationService();
-  final SensorService _sensorService = SensorService();
-  final NotificationService _notificationService = NotificationService();
+  final EstacionamientoService _estacionamientoService;
+  final LocationService _locationService;
+  final SensorService _sensorService;
+  final NotificationService _notificationService;
+
+  MapProvider({
+    EstacionamientoService? estacionamientoService,
+    LocationService? locationService,
+    SensorService? sensorService,
+    NotificationService? notificationService,
+  })  : _estacionamientoService = estacionamientoService ?? EstacionamientoService(),
+        _locationService = locationService ?? LocationService(),
+        _sensorService = sensorService ?? SensorService(),
+        _notificationService = notificationService ?? NotificationService();
 
   // Estado del mapa
   GoogleMapController? _mapController;
@@ -136,6 +146,7 @@ class MapProvider with ChangeNotifier {
 
   // Configurar actualizaciones en tiempo real
   void _setupRealtimeUpdates() {
+    _estacionamientosSubscription?.cancel();
     _estacionamientosSubscription = _estacionamientoService
         .lugaresLibresStream
         .listen((lugares) {

--- a/test/map_provider_test.dart
+++ b/test/map_provider_test.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkit_app/providers/map_provider.dart';
+import 'package:parkit_app/services/estacionamiento_service.dart';
+import 'package:parkit_app/models/estacionamiento_model.dart';
+
+class FakeEstacionamientoService extends EstacionamientoService {
+  final StreamController<List<EstacionamientoModel>> controller =
+      StreamController<List<EstacionamientoModel>>.broadcast();
+  int listenerCount = 0;
+
+  FakeEstacionamientoService() {
+    controller
+      ..onListen = () => listenerCount++
+      ..onCancel = () => listenerCount--;
+  }
+
+  @override
+  Stream<List<EstacionamientoModel>> get lugaresLibresStream => controller.stream;
+
+  @override
+  Future<List<EstacionamientoModel>> getLugaresLibres() async => [];
+
+  @override
+  Future<EstacionamientoModel?> getLugarOcupadoUsuario() async => null;
+}
+
+void main() {
+  test('refresh does not accumulate stream subscriptions', () async {
+    final fakeService = FakeEstacionamientoService();
+    final provider = MapProvider(estacionamientoService: fakeService);
+
+    await provider.initializeMap();
+    expect(fakeService.listenerCount, 1);
+
+    await provider.refresh();
+    expect(fakeService.listenerCount, 1);
+
+    await provider.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- allow injecting services into `MapProvider`
- cancel existing realtime update subscription when re-initializing
- test refresh does not accumulate subscriptions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a366de088329bb1935279094c4e8