### PR TITLE
Implement configurable sensor sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Sensor sensitivity
+
+`SensorService` allows customizing the motion detection thresholds at runtime.
+Call `configureSensitivity` to adjust acceleration or gyroscope thresholds and
+the durations used to determine movement and stability.

--- a/lib/services/sensor_service.dart
+++ b/lib/services/sensor_service.dart
@@ -15,11 +15,11 @@ class SensorService {
   Function()? _onMovementDetected;
   Function()? _onMovementStopped;
 
-  // Configuración de sensibilidad
-  static const double _movementThreshold = 2.0; // m/s²
-  static const double _gyroThreshold = 0.5; // rad/s
-  static const int _stabilityDuration = 3; // segundos para considerar parado
-  static const int _movementDuration = 2; // segundos para confirmar movimiento
+  // Configuración de sensibilidad (valores por defecto)
+  double _movementThreshold = 2.0; // m/s²
+  double _gyroThreshold = 0.5; // rad/s
+  int _stabilityDuration = 3; // segundos para considerar parado
+  int _movementDuration = 2; // segundos para confirmar movimiento
 
   // Variables de estado
   bool _isMonitoring = false;
@@ -36,6 +36,10 @@ class SensorService {
 
   bool get isMonitoring => _isMonitoring;
   bool get isMoving => _isMoving;
+  double get movementThreshold => _movementThreshold;
+  double get gyroThreshold => _gyroThreshold;
+  int get stabilityDuration => _stabilityDuration;
+  int get movementDuration => _movementDuration;
 
   // Iniciar monitoreo de sensores
   Future<void> startMonitoring({
@@ -173,15 +177,26 @@ class SensorService {
     }
   }
 
-  // Configurar sensibilidad personalizada
+  // Configurar sensibilidad personalizada. Cualquier parámetro nulo
+  // mantiene el valor actual.
   void configureSensitivity({
     double? movementThreshold,
     double? gyroThreshold,
     int? stabilityDuration,
     int? movementDuration,
   }) {
-    // Esta implementación usaría variables de instancia en lugar de constantes
-    // Para simplicidad, las constantes están hardcodeadas arriba
+    if (movementThreshold != null) {
+      _movementThreshold = movementThreshold;
+    }
+    if (gyroThreshold != null) {
+      _gyroThreshold = gyroThreshold;
+    }
+    if (stabilityDuration != null) {
+      _stabilityDuration = stabilityDuration;
+    }
+    if (movementDuration != null) {
+      _movementDuration = movementDuration;
+    }
     debugPrint('Sensibilidad configurada');
   }
 

--- a/test/sensor_service_test.dart
+++ b/test/sensor_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkit_app/services/sensor_service.dart';
+
+void main() {
+  test('configureSensitivity updates values', () {
+    final service = SensorService();
+
+    final defaultMovement = service.movementThreshold;
+    final defaultGyro = service.gyroThreshold;
+    final defaultStability = service.stabilityDuration;
+    final defaultMovementDuration = service.movementDuration;
+
+    service.configureSensitivity(
+      movementThreshold: 3.0,
+      gyroThreshold: 1.0,
+      stabilityDuration: 5,
+      movementDuration: 4,
+    );
+
+    expect(service.movementThreshold, 3.0);
+    expect(service.gyroThreshold, 1.0);
+    expect(service.stabilityDuration, 5);
+    expect(service.movementDuration, 4);
+
+    // restore defaults so other tests are unaffected
+    service.configureSensitivity(
+      movementThreshold: defaultMovement,
+      gyroThreshold: defaultGyro,
+      stabilityDuration: defaultStability,
+      movementDuration: defaultMovementDuration,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- make sensor thresholds mutable and expose them with getters
- implement `configureSensitivity`
- document sensor sensitivity usage
- test that `configureSensitivity` updates the values

## Testing
- `flutter test test/sensor_service_test.dart` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a36821e4832986342d9fda824ecd